### PR TITLE
feat: add arm64 support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -83,6 +83,7 @@ get_arch() {
 
   case "$(uname -m)" in
   x86_64 | amd64) arch="amd64" ;;
+  arm64) arch="arm64" ;;
   *)
     echo "Arch '$(uname -m)' not supported!" >&2
     exit 1


### PR DESCRIPTION
arm64 binaries are already available as of https://github.com/jstemmer/go-junit-report/releases/tag/v2.1.0 so provide support for those.